### PR TITLE
Fixed missed JsonIgnore attribute on JsonSchema properties.

### DIFF
--- a/NeuroSDKCsharp/Json/JsonSchema.cs
+++ b/NeuroSDKCsharp/Json/JsonSchema.cs
@@ -1,15 +1,18 @@
 using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace NeuroSDKCsharp.Json;
 
 public sealed class JsonSchema
 {
+    [JsonIgnore]
     public Dictionary<string, JsonSchema> Properties
     {
         get => _properties ??= new Dictionary<string, JsonSchema>();
         set => _properties = value;
     }
 
+    [JsonIgnore]
     public JsonSchemaType Type
     {
         get
@@ -42,12 +45,14 @@ public sealed class JsonSchema
         }
     }
 
+    [JsonIgnore]
     public List<object> Enum
     {
         get => _enum ??= new List<object>();
         set => _enum = value;
     }
 
+    [JsonIgnore]
     public List<string> Required
     {
         get => _required ??= new List<string>();


### PR DESCRIPTION
Current JsonSchema missing [JsonIgnore] attribute on properties which cause both properties and private fields to serialize into a schema.
Original UnitySDK has this attribute on these properties.

For example, instead of the correct schema
`{
  "properties": {
    "message": {
      "type": "string"
    }
  },
  "type": "object",
  "required": [
    "message"
  ]
}`

we get something like this
`{
  "properties": {
    "message": {
      "type": "string",
      "Properties": {},
      "Type": 1,
      "Enum": [],
      "Required": []
    }
  },
  "type": "object",
  "required": [
    "message"
  ],
  "Properties": {
    "message": {
      "properties": {},
      "type": "string",
      "enum": [],
      "required": [],
      "Properties": {},
      "Type": 1,
      "Enum": [],
      "Required": []
    }
  },
  "Type": 16,
  "Enum": [],
  "Required": [
    "message"
  ]
}`