### PR TITLE
Fix typo in ExecutionResult constructor.

### DIFF
--- a/NeuroSDKCsharp/Websocket/ExecutionResult.cs
+++ b/NeuroSDKCsharp/Websocket/ExecutionResult.cs
@@ -7,9 +7,9 @@ public class ExecutionResult
 
     public ExecutionResult(bool successful,string? message)
     {
-        if (String.IsNullOrEmpty(Message))
+        if (string.IsNullOrEmpty(message))
         {
-            Message = "";
+            message = "";
         }
 
         Successful = successful;


### PR DESCRIPTION
It seems there is a typo in ExecutionResult constructor.
Instead of checking the `message` parameter for null, the `Message` property is checked.