### PR TITLE
Target NetFramework 6.0 to match Stardew Valley.

### DIFF
--- a/NeuroSDKCsharp/NeuroSDKCsharp.csproj
+++ b/NeuroSDKCsharp/NeuroSDKCsharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>NeuroSDKCsharp</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
Change TargetFramework to 6.0 to match Stardew Valley's version.
<HintPath> for this project referenced in NeuroStardewValley mod also uses net6.0 binaries.